### PR TITLE
Fix /api/workings to store MyWork entries

### DIFF
--- a/app/api/workings/route.ts
+++ b/app/api/workings/route.ts
@@ -1,20 +1,97 @@
 // app/api/workings/route.ts
 import { NextResponse } from 'next/server';
 import { getPrisma, memStore } from '@/lib/db';
+import { getUserId } from '@/lib/auth';
+
+type WorkType =
+  | 'INITIATION'
+  | 'PASSING'
+  | 'RAISING'
+  | 'INSTALLATION'
+  | 'PRESENTATION'
+  | 'LECTURE'
+  | 'OTHER';
+
+const WORK_LABEL_BY_ENUM: Record<WorkType, string> = {
+  INITIATION: 'Initiation',
+  PASSING: 'Passing',
+  RAISING: 'Raising',
+  INSTALLATION: 'Installation',
+  PRESENTATION: 'Presentation',
+  LECTURE: 'Lecture',
+  OTHER: 'Other',
+};
+
+function labelToEnum(label?: string | null): WorkType {
+  if (!label) return 'OTHER';
+  const normalised = label.trim().toLowerCase();
+  switch (normalised) {
+    case 'initiation':
+    case 'ea':
+      return 'INITIATION';
+    case 'passing':
+    case 'fc':
+      return 'PASSING';
+    case 'raising':
+    case 'mm':
+      return 'RAISING';
+    case 'installation':
+      return 'INSTALLATION';
+    case 'presentation':
+      return 'PRESENTATION';
+    case 'lecture':
+      return 'LECTURE';
+    default:
+      return 'OTHER';
+  }
+}
+
+function parseIncomingWork(body: any): { work: WorkType; candidateName: string | null } {
+  const fromBody = typeof body?.work === 'string' ? (body.work as string) : undefined;
+  if (fromBody) {
+    return { work: labelToEnum(fromBody.replace(/_/g, ' ')), candidateName: body?.candidateName ?? null };
+  }
+
+  const title: string = typeof body?.title === 'string' ? body.title : '';
+  const [maybeWork, maybeCandidate] = title.split('–').map(part => part.trim());
+  const work = labelToEnum(maybeWork);
+  const candidateName = body?.candidateName ?? (maybeCandidate ? maybeCandidate : null);
+  return { work, candidateName };
+}
+
+function toLegacyShape(row: any) {
+  const workEnum: WorkType = row?.work ?? 'OTHER';
+  const label = WORK_LABEL_BY_ENUM[workEnum] ?? WORK_LABEL_BY_ENUM.OTHER;
+  const candidateName = row?.candidateName ?? row?.candidate ?? null;
+  const derivedTitle = candidateName ? `${label} – ${candidateName}` : label;
+  const title = row?.title ?? derivedTitle;
+  const dateValue = row?.date instanceof Date ? row.date.toISOString() : row?.date ?? null;
+  const createdAt = row?.createdAt instanceof Date ? row.createdAt.toISOString() : row?.createdAt ?? null;
+  const updatedAt = row?.updatedAt instanceof Date ? row.updatedAt.toISOString() : row?.updatedAt ?? createdAt;
+
+  return {
+    id: row?.id,
+    title,
+    date: dateValue,
+    lodgeName: row?.lodgeName ?? null,
+    lodgeNumber: row?.lodgeNumber ?? null,
+    notes: row?.notes ?? row?.comments ?? null,
+    createdBy: row?.createdBy ?? row?.userId ?? null,
+    createdAt,
+    updatedAt,
+  };
+}
 
 export async function GET() {
-  const prismaAny = getPrisma() as any;
-  if (prismaAny) {
-    const rows = await prismaAny.lodgeWork.findMany();
-    const sorted = [...rows].sort((a: any, b: any) => {
-      const bKey = (b?.date ?? b?.createdAt ?? b?.updatedAt ?? '').toString();
-      const aKey = (a?.date ?? a?.createdAt ?? a?.updatedAt ?? '').toString();
-      return bKey.localeCompare(aKey);
-    });
-    return NextResponse.json(sorted);
+  const prisma = getPrisma() as any;
+  if (prisma) {
+    const userId = getUserId();
+    if (!userId) return new NextResponse('Unauthorized', { status: 401 });
+    const rows = await prisma.myWork.findMany({ where: { userId }, orderBy: { date: 'desc' } });
+    return NextResponse.json(rows.map(toLegacyShape));
   }
   // fallback
-  return NextResponse.json(memStore.list());
+  return NextResponse.json(memStore.list().map(toLegacyShape));
 }
 
 export async function POST(req: Request) {
@@ -24,21 +101,24 @@ export async function POST(req: Request) {
     return new NextResponse('Title and date are required', { status: 400 });
   }
 
-  const prismaAny = getPrisma() as any;
-  if (prismaAny) {
-    const data: any = {
-      title,
-      date: new Date(date),
-      lodgeName: lodgeName || null,
-      lodgeNumber: lodgeNumber || null,
-      notes: notes || null,
-      createdBy: createdBy || null,
-    };
-    const row = await prismaAny.lodgeWork.create({ data });
-    return NextResponse.json(row, { status: 201 });
+  const prisma = getPrisma() as any;
+  if (prisma) {
+    const userId = getUserId();
+    if (!userId) return new NextResponse('Unauthorized', { status: 401 });
+    const { work, candidateName } = parseIncomingWork(body);
+    const row = await prisma.myWork.create({
+      data: {
+        userId,
+        date: new Date(date),
+        work,
+        candidateName,
+        comments: notes ?? null,
+      },
+    });
+    return NextResponse.json(toLegacyShape(row), { status: 201 });
   }
 
   // fallback
   const created = memStore.create({ title, date, lodgeName, lodgeNumber, notes, createdBy });
-  return NextResponse.json(created, { status: 201 });
+  return NextResponse.json(toLegacyShape(created), { status: 201 });
 }


### PR DESCRIPTION
## Summary
- ensure the legacy /api/workings endpoint maps requests to the authenticated user's MyWork records
- translate incoming title/work values into WorkType enums and return legacy response shapes
- keep the in-memory fallback usable for environments without a database

## Testing
- pnpm lint *(fails: network proxy prevented downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68e4072bd360832cacb4c21e99406a9d