### PR TITLE
Ensure NextAuth route runs on Node runtime

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,7 @@
+import NextAuth from "next-auth";
+import { authConfig } from "@/lib/auth";
+
+export const runtime = "nodejs";
+
+const handler = NextAuth(authConfig);
+export { handler as GET, handler as POST };


### PR DESCRIPTION
## Summary
- add the `app/api/auth/[...nextauth]/route.ts` handler so NextAuth uses the shared auth config
- force the auth route to run on the Node.js runtime to keep bcrypt working

## Testing
- pnpm lint *(fails: missing auth token when installing @types packages automatically)*

------
https://chatgpt.com/codex/tasks/task_e_68e45c862c74832caa6437939a9d80a5