### PR TITLE
Protect leaderboard pages for unauthenticated users

### DIFF
--- a/app/leaderboard/month/page.tsx
+++ b/app/leaderboard/month/page.tsx
@@ -1,8 +1,15 @@
 export const dynamic = "force-dynamic";
 
+import { redirect } from "next/navigation";
+import { getUserId } from "@/lib/auth";
 import { db } from "@/lib/db";
 
 export default async function Page() {
+  const uid = getUserId();
+  if (!uid) {
+    redirect(`/login?redirect=${encodeURIComponent("/leaderboard/month")}`);
+  }
+
   const now = new Date();
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,4 +1,12 @@
+import { redirect } from "next/navigation";
+import { getUserId } from "@/lib/auth";
+
 export default function LeaderboardPage() {
+  const uid = getUserId();
+  if (!uid) {
+    redirect("/login?redirect=/leaderboard");
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">

--- a/app/leaderboard/year/page.tsx
+++ b/app/leaderboard/year/page.tsx
@@ -1,8 +1,15 @@
 export const dynamic = "force-dynamic";
 
+import { redirect } from "next/navigation";
+import { getUserId } from "@/lib/auth";
 import { db } from "@/lib/db";
 
 export default async function Page() {
+  const uid = getUserId();
+  if (!uid) {
+    redirect(`/login?redirect=${encodeURIComponent("/leaderboard/year")}`);
+  }
+
   const now = new Date();
   const yearAgo = new Date(now);
   yearAgo.setFullYear(yearAgo.getFullYear() - 1);


### PR DESCRIPTION
## Summary
- gate the top-level leaderboard page behind the session cookie check
- redirect unauthenticated visitors from the monthly and yearly leaderboard views back to login

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ab148de8832c8b0f36c5dece1b67